### PR TITLE
mysqldump: make correct dump of UTF-8 databases

### DIFF
--- a/pages/common/mysql.md
+++ b/pages/common/mysql.md
@@ -18,6 +18,6 @@
 
 `mysql --socket {{path/to/socket.sock}}`
 
-- Execute SQL statements in a script file (batch file):
+- Execute SQL statements in a script file (batch file), user will be prompted for a password:
 
-`mysql -h {{database_host}} -u {{user}} --password {{database_name}} -e "source {{/path/to/backup-file.sql]}" {{database_name}}`
+`mysql -u {{user}} --password -e "source {{filename.sql}}" {{database_name}}`

--- a/pages/common/mysql.md
+++ b/pages/common/mysql.md
@@ -20,4 +20,4 @@
 
 - Execute SQL statements in a script file (batch file), user will be prompted for a password:
 
-`mysql -u {{user}} --password -e "source {{filename.sql}}" {{database_name}}`
+`mysql -e "source {{filename.sql}}" {{database_name}}`

--- a/pages/common/mysql.md
+++ b/pages/common/mysql.md
@@ -18,6 +18,6 @@
 
 `mysql --socket {{path/to/socket.sock}}`
 
-- Execute SQL statements in a script file (batch file), user will be prompted for a password:
+- Execute SQL statements in a script file (batch file):
 
 `mysql -e "source {{filename.sql}}" {{database_name}}`

--- a/pages/common/mysql.md
+++ b/pages/common/mysql.md
@@ -20,4 +20,4 @@
 
 - Execute SQL statements in a script file (batch file):
 
-`mysql {{database_name}} < {{script.sql}}`
+`mysql -h {{database_host}} -u {{user}} --password {{database_name}} -e "source {{/path/to/backup-file.sql]}" {{database_name}}`

--- a/pages/common/mysqldump.md
+++ b/pages/common/mysqldump.md
@@ -8,4 +8,4 @@
 
 - Restore a backup, user will be prompted for a password:
 
-`mysql -u {{user}} --password {{database_name}} -e "source {{/path/to/backup-file.sql]}" {{database_name}}`
+`mysql -u {{user}} --password -e "source {{filename.sql}}" {{database_name}}`

--- a/pages/common/mysqldump.md
+++ b/pages/common/mysqldump.md
@@ -4,8 +4,8 @@
 
 - Create a backup, user will be prompted for a password:
 
-`mysqldump -u {{user}} --password {{database_name}} > {{filename.sql}}`
+`mysqldump -u {{user}} --password {{database_name}} -r {{filename.sql}}`
 
 - Restore a backup, user will be prompted for a password:
 
-`mysql -u {{user}} --password {{database_name}} < {{filename.sql}}`
+`mysql -u {{user}} --password {{database_name}} -e "source {{/path/to/backup-file.sql]}" {{database_name}}`


### PR DESCRIPTION
Make sure to use the `-r <filename>` option, instead of redirecting command-line output to a file `> <filename>`. Redirection does not capture UTF characters properly, while the -r option does.

As well the import was changed to fix the same issue.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [ x] The page has 8 or fewer examples. (this is an edit)

- [ x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [ x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
